### PR TITLE
Disallow illegal values

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,6 +114,9 @@ function handleAmountChange(e) {
 }
 
 function handleConvertClick(e) {
+  if (amountInput.value.length === 0 || amountInput.value <= 0) {
+    return;
+  }
   const amount = Number.parseFloat(amountInput.value);
 
   updateInputValues(amount, initialDecimals);


### PR DESCRIPTION
Don't allow conversion if the input field is empty or if the value
is less than 0.

Close #6